### PR TITLE
Update podspec

### DIFF
--- a/AutomaticSDK.podspec
+++ b/AutomaticSDK.podspec
@@ -1,19 +1,24 @@
 Pod::Spec.new do |s|
-  s.name         = "AutomaticSDK"
-  s.version      = "0.0.1"
-  s.summary      = "The official Automatic SDK for iOS."
+  s.name         = 'AutomaticSDK'
+  s.version      = '0.0.1'
+  s.summary      = 'The official Automatic SDK for iOS.'
   s.description  = <<-DESC
-                   A handy wrapper that makes authenticating with the Automatic
-                   API a breeze.
-                   DESC
-  s.homepage     = "https://developer.automatic.com"
-  s.license      = "Apache 2.0"
-  s.author       = { "Robert Böhnke" => "robb.bohnke@automatic.com" }
-  s.source       = { :git => "https://github.com/Automatic/Automatic-iOS-SDK.git", :tag => "0.0.1" }
-  s.source_files = "AutomaticSDK", "AutomaticSDK/**/*.{h,m}"
+A handy wrapper that makes authenticating with the Automatic API a breeze.
+DESC
+  s.homepage     = 'https://developer.automatic.com'
+  s.license      = 'Apache 2.0'
+  s.authors      = {
+    'Robert Böhnke' => 'robb.bohnke@automatic.com',
+    'Eric Horacek' => 'eric@automatic.com'
+  }
+  s.source       = {
+    :git => 'https://github.com/Automatic/Automatic-iOS-SDK.git',
+    :tag => '0.0.1'
+  }
+  s.source_files = 'AutomaticSDK', 'AutomaticSDK/**/*.{h,m}'
   s.requires_arc = true
-  s.platform     = :ios, "8.0"
+  s.platform     = :ios, '8.0'
 
-  s.dependency "AFNetworking",    "~> 2.5"
-  s.dependency "AFOAuth2Manager", "~> 2.2"
+  s.dependency 'AFNetworking',    '~> 2.5'
+  s.dependency 'AFOAuth2Manager', '~> 2.2'
 end


### PR DESCRIPTION
- Remove newlines from description to fix results in pod search
- Add me as an author
- Replace ' with " to match ruby conventions (only use double quotes when substitution is used, single quotes otherwise)

If you look at https://github.com/CocoaPods/Specs/commit/7c61d1be4650b934bb69c72468778c011ff19f81 the description is all mangled due to the description being on multiple lines. This fixes that.