### PR TITLE
Update nullablity annotations to Xcode 6.3 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
+osx_image: beta-xcode6.3
 env:
   global:
   - LANG=en_US.UTF-8

--- a/AutomaticSDK/AUTClient+Pagination.h
+++ b/AutomaticSDK/AUTClient+Pagination.h
@@ -8,7 +8,7 @@
 
 #import <AutomaticSDK/AutomaticSDK.h>
 
-#pragma clang assume_nonnull begin
+NS_ASSUME_NONNULL_BEGIN
 
 @interface AUTClient (Pagination)
 
@@ -23,8 +23,8 @@
  *
  *  @return An `AFHTTPRequestOperation` representing the request.
  */
-- (AFHTTPRequestOperation *)fetchPage:(NSURL *)pageURL success:(void(^ __aut_nullable)(__aut_nullable NSDictionary *))success failure:(void(^ __aut_nullable)(__aut_nullable NSError *))failure;
+- (AFHTTPRequestOperation *)fetchPage:(NSURL *)pageURL success:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure;
 
 @end
 
-#pragma clang assume_nonnull end
+NS_ASSUME_NONNULL_END

--- a/AutomaticSDK/AUTClient+Pagination.m
+++ b/AutomaticSDK/AUTClient+Pagination.m
@@ -12,7 +12,7 @@
 
 @implementation AUTClient (Pagination)
 
-- (AFHTTPRequestOperation *)fetchPage:(NSURL *)pageURL success:(void(^)(NSDictionary *))success failure:(void(^)(NSError *))failure {
+- (AFHTTPRequestOperation *)fetchPage:(NSURL *)pageURL success:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure {
     NSParameterAssert(pageURL != nil);
 
     NSError *error;

--- a/AutomaticSDK/AUTClient+Trip.h
+++ b/AutomaticSDK/AUTClient+Trip.h
@@ -8,7 +8,7 @@
 
 #import <AutomaticSDK/AutomaticSDK.h>
 
-#pragma clang assume_nonnull begin
+NS_ASSUME_NONNULL_BEGIN
 
 @class AFHTTPRequestOperation;
 
@@ -24,7 +24,7 @@
  *
  *  @return An `AFHTTPRequestOperation` representing the request.
  */
-- (AFHTTPRequestOperation *)fetchTripsForCurrentUserWithSuccess:(void(^ __aut_nullable)(__aut_nullable NSDictionary *))success failure:(void(^ __aut_nullable)(__aut_nullable NSError *))failure;
+- (AFHTTPRequestOperation *)fetchTripsForCurrentUserWithSuccess:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure;
 
 /**
  *  Fetches the trips belonging to the user with the given ID.
@@ -38,7 +38,7 @@
  *
  *  @return An `AFHTTPRequestOperation` representing the request.
  */
-- (AFHTTPRequestOperation *)fetchTripsForUserWithID:(NSString *)userID success:(void(^ __aut_nullable)(__aut_nullable NSDictionary *))success failure:(void(^ __aut_nullable)(__aut_nullable NSError *))failure;
+- (AFHTTPRequestOperation *)fetchTripsForUserWithID:(NSString *)userID success:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure;
 
 /**
  *  Fetches a trip with a given ID.
@@ -52,8 +52,8 @@
  *
  *  @return An `AFHTTPRequestOperation` representing the request.
  */
-- (AFHTTPRequestOperation *)fetchTripWithID:(NSString *)tripID success:(void(^ __aut_nullable)(__aut_nullable NSDictionary *))success failure:(void(^ __aut_nullable)(__aut_nullable NSError *))failure;
+- (AFHTTPRequestOperation *)fetchTripWithID:(NSString *)tripID success:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure;
 
 @end
 
-#pragma clang assume_nonnull end
+NS_ASSUME_NONNULL_END

--- a/AutomaticSDK/AUTClient+Trip.m
+++ b/AutomaticSDK/AUTClient+Trip.m
@@ -12,7 +12,7 @@
 
 @implementation AUTClient (Trip)
 
-- (AFHTTPRequestOperation *)fetchTripsForCurrentUserWithSuccess:(void(^)(NSDictionary *))success failure:(void(^)(NSError *))failure {
+- (AFHTTPRequestOperation *)fetchTripsForCurrentUserWithSuccess:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure {
     return [self.requestManager
         GET:@"trip/"
         parameters:nil
@@ -20,7 +20,7 @@
         failure:AUTExtractError(failure)];
 }
 
-- (AFHTTPRequestOperation *)fetchTripsForUserWithID:(NSString *)userID success:(void(^)(NSDictionary *))success failure:(void(^)(NSError *))failure {
+- (AFHTTPRequestOperation *)fetchTripsForUserWithID:(NSString *)userID success:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure {
     NSParameterAssert(userID != nil);
 
     return [self.requestManager
@@ -30,7 +30,7 @@
         failure:AUTExtractError(failure)];
 }
 
-- (AFHTTPRequestOperation *)fetchTripWithID:(NSString *)tripID success:(void(^)(NSDictionary *))success failure:(void(^)(NSError *))failure {
+- (AFHTTPRequestOperation *)fetchTripWithID:(NSString *)tripID success:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure {
     NSParameterAssert(tripID != nil);
 
     return [self.requestManager

--- a/AutomaticSDK/AUTClient+User.h
+++ b/AutomaticSDK/AUTClient+User.h
@@ -8,7 +8,7 @@
 
 #import <AutomaticSDK/AutomaticSDK.h>
 
-#pragma clang assume_nonnull begin
+NS_ASSUME_NONNULL_BEGIN
 
 @class AFHTTPRequestOperation;
 
@@ -24,7 +24,7 @@
  *
  *  @return An `AFHTTPRequestOperation` representing the request.
  */
-- (AFHTTPRequestOperation *)fetchCurrentUserWithSuccess:(void(^ __aut_nullable)(__aut_nullable NSDictionary *))success failure:(void(^ __aut_nullable)(__aut_nullable NSError *))failure;
+- (AFHTTPRequestOperation *)fetchCurrentUserWithSuccess:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure;
 
 /**
  *  Fetches a user with a given ID.
@@ -38,8 +38,8 @@
  *
  *  @return An `AFHTTPRequestOperation` representing the request.
  */
-- (AFHTTPRequestOperation *)fetchCurrentUserWithID:(NSString *)userID success:(void(^ __aut_nullable)(__aut_nullable NSDictionary *))success failure:(void(^ __aut_nullable)(__aut_nullable NSError *))failure;
+- (AFHTTPRequestOperation *)fetchCurrentUserWithID:(NSString *)userID success:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure;
 
 @end
 
-#pragma clang assume_nonnull end
+NS_ASSUME_NONNULL_END

--- a/AutomaticSDK/AUTClient+User.m
+++ b/AutomaticSDK/AUTClient+User.m
@@ -12,7 +12,7 @@
 
 @implementation AUTClient (User)
 
-- (AFHTTPRequestOperation *)fetchCurrentUserWithSuccess:(void(^)(NSDictionary *))success failure:(void(^)(NSError *))failure {
+- (AFHTTPRequestOperation *)fetchCurrentUserWithSuccess:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure {
     return [self.requestManager
         GET:@"user/me/"
         parameters:nil
@@ -20,7 +20,7 @@
         failure:AUTExtractError(failure)];
 }
 
-- (AFHTTPRequestOperation *)fetchCurrentUserWithID:(NSString *)userID success:(void(^)(NSDictionary *))success failure:(void(^)(NSError *))failure {
+- (AFHTTPRequestOperation *)fetchCurrentUserWithID:(NSString *)userID success:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure {
     NSParameterAssert(userID != nil);
 
     return [self.requestManager

--- a/AutomaticSDK/AUTClient+Vehicle.h
+++ b/AutomaticSDK/AUTClient+Vehicle.h
@@ -8,7 +8,7 @@
 
 #import <AutomaticSDK/AutomaticSDK.h>
 
-#pragma clang assume_nonnull begin
+NS_ASSUME_NONNULL_BEGIN
 
 @class AFHTTPRequestOperation;
 
@@ -24,7 +24,7 @@
  *
  *  @return An `AFHTTPRequestOperation` representing the request.
  */
-- (AFHTTPRequestOperation *)fetchVehiclesForCurrentUserWithSuccess:(void(^ __aut_nullable)(__aut_nullable NSDictionary *))success failure:(void(^ __aut_nullable)(__aut_nullable NSError *))failure;
+- (AFHTTPRequestOperation *)fetchVehiclesForCurrentUserWithSuccess:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure;
 
 /**
  *  Fetches the vehicles belonging to the user with the given ID.
@@ -38,7 +38,7 @@
  *
  *  @return An `AFHTTPRequestOperation` representing the request.
  */
-- (AFHTTPRequestOperation *)fetchVehiclesForUserWithID:(NSString *)userID success:(void(^ __aut_nullable)(__aut_nullable NSDictionary *))success failure:(void(^ __aut_nullable)(__aut_nullable NSError *))failure;
+- (AFHTTPRequestOperation *)fetchVehiclesForUserWithID:(NSString *)userID success:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure;
 
 /**
  *  Fetches a vehicles with a given ID.
@@ -52,8 +52,8 @@
  *
  *  @return An `AFHTTPRequestOperation` representing the request.
  */
-- (AFHTTPRequestOperation *)fetchVehicleWithID:(NSString *)vehicleID success:(void(^ __aut_nullable)(__aut_nullable NSDictionary *))success failure:(void(^ __aut_nullable)(__aut_nullable NSError *))failure;
+- (AFHTTPRequestOperation *)fetchVehicleWithID:(NSString *)vehicleID success:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure;
 
 @end
 
-#pragma clang assume_nonnull end
+NS_ASSUME_NONNULL_END

--- a/AutomaticSDK/AUTClient+Vehicle.m
+++ b/AutomaticSDK/AUTClient+Vehicle.m
@@ -12,7 +12,7 @@
 
 @implementation AUTClient (Vehicle)
 
-- (AFHTTPRequestOperation *)fetchVehiclesForCurrentUserWithSuccess:(void(^)(NSDictionary *))success failure:(void(^)(NSError *))failure {
+- (AFHTTPRequestOperation *)fetchVehiclesForCurrentUserWithSuccess:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure {
     return [self.requestManager
         GET:@"vehicle/"
         parameters:nil
@@ -20,7 +20,7 @@
         failure:AUTExtractError(failure)];
 }
 
-- (AFHTTPRequestOperation *)fetchVehiclesForUserWithID:(NSString *)userID success:(void(^)(NSDictionary *))success failure:(void(^)(NSError *))failure {
+- (AFHTTPRequestOperation *)fetchVehiclesForUserWithID:(NSString *)userID success:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure {
     NSParameterAssert(userID != nil);
 
     return [self.requestManager
@@ -30,7 +30,7 @@
         failure:AUTExtractError(failure)];
 }
 
-- (AFHTTPRequestOperation *)fetchVehicleWithID:(NSString *)vehicleID success:(void(^)(NSDictionary *))success failure:(void(^)(NSError *))failure {
+- (AFHTTPRequestOperation *)fetchVehicleWithID:(NSString *)vehicleID success:(nullable AUTResponseBlock)success failure:(nullable AUTFailureBlock)failure {
     NSParameterAssert(vehicleID != nil);
 
     return [self.requestManager

--- a/AutomaticSDK/AUTClient.h
+++ b/AutomaticSDK/AUTClient.h
@@ -8,29 +8,17 @@
 
 #import <Foundation/Foundation.h>
 
-// Allow the use of nullability attributes while keeping compatibility with
-// Xcode 6.1 and 6.2
-#if __has_feature(nullability)
-#define aut_nonnull nonnull
-#define aut_nullable nullable
-#define aut_null_unspecified null_unspecified
-#define __aut_nonnull __nonnull
-#define __aut_nullable __nullable
-#define __aut_null_unspecified __null_unspecified
-#else
-#define aut_nonnull
-#define aut_nullable
-#define aut_null_unspecified
-#define __aut_nonnull
-#define __aut_nullable
-#define __aut_null_unspecified
-#endif
-
-#pragma clang assume_nonnull begin
+NS_ASSUME_NONNULL_BEGIN
 
 @class AFHTTPRequestOperation;
 @class AFHTTPRequestOperationManager;
 @class AFOAuthCredential;
+
+typedef void(^AUTSuccessBlock)(void);
+
+typedef void(^AUTResponseBlock)(NSDictionary * __nullable);
+
+typedef void(^AUTFailureBlock)(NSError * __nullable);
 
 /**
  *  The different scopes an `AUTClient` can request.
@@ -117,7 +105,7 @@ extern const NSInteger AUTClientErrorAuthorizationFailed;
  *  See +[AFOAuthCredential storeCredential:withIdentifier:] on information how
  *  to persist this credential.
  */
-@property (readwrite, nonatomic, strong, aut_nullable) AFOAuthCredential *credential;
+@property (readwrite, nonatomic, strong, nullable) AFOAuthCredential *credential;
 
 /**
  *  The `AFHTTPRequestOperationManager` used by the client.
@@ -159,7 +147,7 @@ extern const NSInteger AUTClientErrorAuthorizationFailed;
  *  @param failure A block to be invoked with an error if the authorization
  *                 fails.
  */
-- (void)authorizeWithScopes:(AUTClientScopes)scopes success:(aut_nullable void(^)(void))success failure:(aut_nullable void(^)(__aut_nullable NSError *))failure;
+- (void)authorizeWithScopes:(AUTClientScopes)scopes success:(nullable AUTSuccessBlock)success failure:(nullable AUTFailureBlock)failure;
 
 /**
  *  Complete the authorization flow by calling this method.
@@ -184,7 +172,7 @@ extern const NSInteger AUTClientErrorAuthorizationFailed;
  *  @param failure    A block to be invoked with an error if the authorization
  *                    fails.
  */
-- (void)authorizeByRefreshingCredential:(AFOAuthCredential *)credential success:(aut_nullable void(^)(void))success failure:(aut_nullable void(^)(__aut_nullable NSError *))failure;
+- (void)authorizeByRefreshingCredential:(AFOAuthCredential *)credential success:(nullable AUTSuccessBlock)success failure:(nullable AUTFailureBlock)failure;
 
 @end
 
@@ -192,22 +180,23 @@ extern const NSInteger AUTClientErrorAuthorizationFailed;
  *  Converts a block that takes an `NSDictionary` as its only argument into one
  *  that can be used as a success callback with `AFHTTPRequestOperationManager`.
  *
- *  @param ^block The block to convert.
+ *  @param block The block to convert.
  *
  *  @return A block that can be used as a success callback to
  *          `AFHTTPRequestOperationManager` or `nil` if the block was `nil`.
  */
-extern void (^__aut_nullable AUTExtractResponseObject(void (^__aut_nullable block)(__aut_nullable NSDictionary *)))(__aut_nullable AFHTTPRequestOperation *, __aut_nullable id);
+extern void (^ __nullable AUTExtractResponseObject(__nullable AUTResponseBlock block))(AFHTTPRequestOperation * __nullable, id __nullable);
 
 /**
  *  Converts a block that takes an `NSError *` as its only argument into one
  *  that can be used as a failure callback with `AFHTTPRequestOperationManager`.
  *
- *  @param ^block The block to convert.
+ *  @param block The block to convert.
  *
  *  @return A block that can be used as a failure callback to
  *          `AFHTTPRequestOperationManager` or `nil` if the block was `nil`.
  */
-extern void (^__aut_nullable AUTExtractError(void (^__aut_nullable block)(__aut_nullable NSError *)))(__aut_nullable AFHTTPRequestOperation *, __aut_nullable NSError *);
+extern void (^ __nullable AUTExtractError(__nullable AUTFailureBlock block))(AFHTTPRequestOperation * __nullable, NSError * __nullable);
 
-#pragma clang assume_nonnull end
+NS_ASSUME_NONNULL_END
+

--- a/AutomaticSDK/AUTClient.m
+++ b/AutomaticSDK/AUTClient.m
@@ -48,7 +48,7 @@ const NSInteger AUTClientErrorAuthorizationFailed = 1;
  *  @param failure A block to be invoked with an error if the authorization
  *                 fails.
  */
-- (void)authorizeWithCode:(NSString *)code success:(aut_nullable void(^)(void))success failure:(aut_nullable void(^)(__aut_nullable NSError *))failure;
+- (void)authorizeWithCode:(NSString *)code success:(nullable AUTSuccessBlock)success failure:(nullable AUTFailureBlock)failure;
 
 @end
 
@@ -293,7 +293,7 @@ const NSInteger AUTClientErrorAuthorizationFailed = 1;
 
 @end
 
-extern void (^AUTExtractResponseObject(void (^callback)(NSDictionary *)))(AFHTTPRequestOperation *, id) {
+extern void (^ __nullable AUTExtractResponseObject(void (^ __nullable callback)(NSDictionary * __nullable)))(AFHTTPRequestOperation * __nullable, id __nullable) {
     if (callback == nil) return nil;
 
     return ^(AFHTTPRequestOperation *_, id responseObject) {

--- a/AutomaticSDK/AUTClient.m
+++ b/AutomaticSDK/AUTClient.m
@@ -293,7 +293,7 @@ const NSInteger AUTClientErrorAuthorizationFailed = 1;
 
 @end
 
-extern void (^ __nullable AUTExtractResponseObject(void (^ __nullable callback)(NSDictionary * __nullable)))(AFHTTPRequestOperation * __nullable, id __nullable) {
+extern void (^ __nullable AUTExtractResponseObject(__nullable AUTResponseBlock callback))(AFHTTPRequestOperation * __nullable, id __nullable) {
     if (callback == nil) return nil;
 
     return ^(AFHTTPRequestOperation *_, id responseObject) {
@@ -301,7 +301,7 @@ extern void (^ __nullable AUTExtractResponseObject(void (^ __nullable callback)(
     };
 }
 
-extern void (^AUTExtractError(void (^callback)(NSError *)))(AFHTTPRequestOperation *, NSError *) {
+extern void (^ __nullable AUTExtractError(__nullable AUTFailureBlock callback))(AFHTTPRequestOperation * __nullable, NSError * __nullable) {
     if (callback == nil) return nil;
 
     return ^(AFHTTPRequestOperation *_, NSError *error) {


### PR DESCRIPTION
This replaces our home-grown compatibility annotations with the ones native to Xcode 6.3, now that it is out of beta.

To make the headers a little easier on the eyes, I added `typedef`s for the common response and failure blocks:

``` objc
typedef void(^AUTSuccessBlock)(void);
typedef void(^AUTResponseBlock)(NSDictionary * __nullable);
typedef void(^AUTFailureBlock)(NSError * __nullable);
```

Note that since there is currently no Xcode 6.3 support on travisci, this may break the build.

Fixes #8 
