### PR TITLE
Run pod repo update in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   - LANG=en_US.UTF-8
 install:
 - bundle install --jobs=3 --retry=3
+- bundle exec pod repo update
 - bundle exec pod install
 script:
 - bundle exec rake lint


### PR DESCRIPTION
CocoaPods does not perform a `pod repo update` as a side-effect of a `pod install`, so we do so explicitly here.